### PR TITLE
Skip auth when posting to stop_impersonating

### DIFF
--- a/app/controllers/concerns/samvera/persona/avalon_auth.rb
+++ b/app/controllers/concerns/samvera/persona/avalon_auth.rb
@@ -3,7 +3,7 @@ module Samvera
     module AvalonAuth
       extend ActiveSupport::Concern
       included do
-        before_action :auth
+        before_action :auth, except: [:stop_impersonating]
       end
 
       def auth


### PR DESCRIPTION
Auth checks if the current_ability using the impersonated current_user `can? :manage, User` causing an AccessDenied error blocking the user from ending the impersonation.  stop_impersonating should be safe to call as any user so just skip the auth check.  Alternatively a `true_ability` could be setup similar to `true_user` which could be used for the `can?` check in `:auth`