### PR TITLE
Remove Config to Force Rspec Tests to be Generated

### DIFF
--- a/lib/samvera-persona/engine.rb
+++ b/lib/samvera-persona/engine.rb
@@ -19,13 +19,6 @@ module Samvera
         end
       end
 
-      config.generators do |g|
-        g.test_framework :rspec, :fixture => false
-        g.fixture_replacement :factory_bot, :dir => 'spec/factories'
-        g.assets false
-        g.helper false
-      end
-
       config.before_initialize do
         config.i18n.load_path += Dir["#{config.root}/config/locales/**/*.yml"]
       end


### PR DESCRIPTION
Forcing upstream to use rspec isn't really in-scope of the engine.