### PR TITLE
Ruby 2.7 fixes

### DIFF
--- a/samvera-persona.gemspec
+++ b/samvera-persona.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'paranoia', '~> 2.2'
   s.add_dependency 'pretender'
   s.add_dependency 'devise', '~> 4.6'
-  s.add_dependency 'devise_invitable', '~> 1.7'
+  s.add_dependency 'devise_invitable', '>= 1.7', '< 3.0'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
Update dependency version requirement for `devise_invitable` to fix URI.encode obsolescence warnings.